### PR TITLE
add ratio calculation

### DIFF
--- a/plotify/plotify.py
+++ b/plotify/plotify.py
@@ -79,7 +79,7 @@ def _check_valid_ratio_column_map(some_dict):
     except KeyError:
         raise Exception('the calculation dict is missing a denominator key-value pair')
 
-    if not all(a, b, c):
+    if not all([a, b, c]):
         raise Exception('All column name references in the calculation must be strings')
 
     return True

--- a/plotify/plotify.py
+++ b/plotify/plotify.py
@@ -65,7 +65,7 @@ def _get_column_cardinality(df, column_name):
 
     return df[column_name].nunique()
 
-def _check_valid_calculation(some_dict):
+def _check_valid_ratio_column_map(some_dict):
     try:
         a = isinstance(some_dict['name'], basestring)
     except KeyError:
@@ -79,7 +79,7 @@ def _check_valid_calculation(some_dict):
     except KeyError:
         raise Exception('the calculation dict is missing a denominator key-value pair')
 
-    if not (a and b and c):
+    if not all(a, b, c):
         raise Exception('All column name references in the calculation must be strings')
 
     return True
@@ -103,7 +103,7 @@ def _format_data(df, value, x, plot_by=None, color_by=None, aggregate=True):
     df = df.copy()
 
     if isinstance(value, dict):
-        _check_valid_calculation(value)
+        _check_valid_ratio_column_map(value)
     else:
         if not is_numeric_dtype(df[value]):
             message = "The value column " + value + " is not numeric"

--- a/plotify/test_plotify.py
+++ b/plotify/test_plotify.py
@@ -1,4 +1,6 @@
-from plotify import _get_column_type, _get_column_cardinality, _format_data, SUBPLOT_COLUMN_NAME,\
+#from plotify import _get_column_type, _get_column_cardinality, _format_data, SUBPLOT_COLUMN_NAME,\
+#    COLOR_BY_COLUMN_NAME
+from .plotify import _get_column_type, _get_column_cardinality, _format_data, SUBPLOT_COLUMN_NAME,\
     COLOR_BY_COLUMN_NAME
 import pandas as pd
 import numpy as np
@@ -75,4 +77,19 @@ def test_plotby_colorby():
                              'metric_1': df.metric_1}).\
         groupby([SUBPLOT_COLUMN_NAME, COLOR_BY_COLUMN_NAME, 'dim_1'])['metric_1'].sum().reset_index()
 
+    assert actual.to_dict() == expected.to_dict()
+
+def test_ratio_calculation():
+    df = gen_df()
+    df['metric_1'] = df['metric_1'] + 1
+    df['metric_2'] = 2*(df['metric_1'])
+    actual = _format_data(df=df,
+                          value={'name': 'this_ratio', 'numerator': 'metric_1', 'denominator': 'metric_2'},
+                          x='dim_1')
+    expected = pd.DataFrame({SUBPLOT_COLUMN_NAME:'',
+                             COLOR_BY_COLUMN_NAME: '',
+                             'dim_1': df.dim_1,
+                             'metric_1': df.metric_1,
+                             'metric_2': df.metric_2,
+                             'this_ratio': 10*[0.5]})
     assert actual.to_dict() == expected.to_dict()


### PR DESCRIPTION
 This PR adds capability to calcuate a ratio of two columns at the appropriate level of aggregation for the plot (using sum() operation)

The code works as it is. I chose to go with the following strategy:
1. If a user wants a ratio calculation, they have to supply a dict to the value argument instead of a column name
2. the dict has the format `{'name': 'calculated_column_name', 'numerator': 'df_column_name', 'denomirator': 'df_column_name'}`
3. The logic is then to check is value is a dict and a: make sure the dict is valid (has the correct keys) and 2 do the calculation and make sure nothing else breaks

An alternative approach to this would be to add an new argument named calculation that would be a dict `{'type': 'ratio', 'numerator': 'df_column_name','denomirator': 'df_column_name'}` and in that case value would be a column name in which the result is written

Both have pros and cons, let me know what you think